### PR TITLE
UpdateInterval: expect minutes instead of hours

### DIFF
--- a/knotenalarm.go
+++ b/knotenalarm.go
@@ -94,7 +94,7 @@ func main() {
 
 	check(gcfg.ReadFileInto(&cfg, "myconfig.gcfg"))
 
-	now := time.Now().Add(-cfg.Config.UpdateInterval * time.Hour)
+	now := time.Now().Add(-cfg.Config.UpdateInterval * time.Minute)
 
 	anaconda.SetConsumerKey(cfg.Anaconda.ConsumerKey)
 	anaconda.SetConsumerSecret(cfg.Anaconda.ConsumerSecret)

--- a/myconfig.gcfg.sample
+++ b/myconfig.gcfg.sample
@@ -4,9 +4,9 @@
 # See https://wiki.openstreetmap.org/wiki/Nominatim for further information
 # Email = email@example.com.
 
-# Update interval in [hours]
+# Update interval in [minutes]
 # schedule crontab accordingly
-UpdateInterval = 1
+UpdateInterval = 60
 
 # Uncomment for debug, knotenalarm will not tweet then.
 Debug


### PR DESCRIPTION
Especially for dedicated twitter accounts a lower update interval might be interesting and since there is literally no cost involved this is quite feasible.

Intervals like quarter-hourly or half-hourly could be specified this way.
